### PR TITLE
Fix corrupt config files

### DIFF
--- a/example/gitlab/qpkg.cfg
+++ b/example/gitlab/qpkg.cfg
@@ -1,7 +1,7 @@
 # Name of the packaged application.
 QPKG_NAME="gitlab"
 QPKG_DISPLAYNAME="GitLab"
-# Version of the packaged application. 
+# Version of the packaged application.
 QPKG_VER="8.16.6"
 # Author or maintainer of the package
 QPKG_AUTHOR="terrychen@qnap.com"

--- a/example/joomla/qpkg.cfg
+++ b/example/joomla/qpkg.cfg
@@ -1,7 +1,7 @@
 # Name of the packaged application.
 QPKG_NAME="joomla"
 QPKG_DISPLAYNAME="Joomla!"
-# Version of the packaged application. 
+# Version of the packaged application.
 QPKG_VER="3.6.0"
 # Author or maintainer of the package
 QPKG_AUTHOR="terrychen@qnap.com"

--- a/example/nginx/qpkg.cfg
+++ b/example/nginx/qpkg.cfg
@@ -1,7 +1,7 @@
 # Name of the packaged application.
 QPKG_NAME="nginx"
 QPKG_DISPLAYNAME="Nginx"
-# Version of the packaged application. 
+# Version of the packaged application.
 QPKG_VER="1.11"
 # Author or maintainer of the package
 QPKG_AUTHOR="terrychen@qnap.com"

--- a/example/redmine/qpkg.cfg
+++ b/example/redmine/qpkg.cfg
@@ -1,7 +1,7 @@
 # Name of the packaged application.
 QPKG_NAME="redmine"
 QPKG_DISPLAYNAME="Redmine"
-# Version of the packaged application. 
+# Version of the packaged application.
 QPKG_VER="3.3.0"
 # Author or maintainer of the package
 QPKG_AUTHOR="terrychen@qnap.com"


### PR DESCRIPTION
The demo build errors because of a crlf in qpkg.cfg
```
qpkg.cfg: line 12: $'\r': command not found
qpkg.cfg: line 18: $'\r': command not found
qpkg.cfg: line 40: $'\r': command not found
qpkg.cfg: line 46: $'\r': command not found
qpkg.cfg: corrupt configuration file
```